### PR TITLE
Fix a merging mistake which broke taskwait in templates

### DIFF
--- a/lib/Sema/TreeTransform.h
+++ b/lib/Sema/TreeTransform.h
@@ -6582,7 +6582,7 @@ StmtResult TreeTransform<Derived>::TransformSEHHandler(Stmt *Handler) {
 template<typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformOMPExecutableDirective(
-                                 OMPExecutableDirective *D) {
+                                            OMPExecutableDirective *D) {
   // Transform the clauses
   llvm::SmallVector<OMPClause *, 5> TClauses;
   ArrayRef<OMPClause *> Clauses = D->clauses();
@@ -6599,12 +6599,13 @@ TreeTransform<Derived>::TransformOMPExecutableDirective(
       TClauses.push_back(0);
     }
   }
-  if (!D->getAssociatedStmt()) {
-    return StmtError();
-  }
-  StmtResult AssociatedStmt =
-    getDerived().TransformStmt(D->getAssociatedStmt());
-  if (AssociatedStmt.isInvalid())
+  StmtResult AssociatedStmt;
+  if (D->hasAssociatedStmt() && D->getAssociatedStmt()) {
+    AssociatedStmt =
+      getDerived().TransformStmt(D->getAssociatedStmt());
+    if (!AssociatedStmt.isUsable())
+      return StmtError();
+  } else if (D->hasAssociatedStmt())
     return StmtError();
   Stmt *AStmt = AssociatedStmt.take();
   DeclarationNameInfo DirName;

--- a/test/OpenMP/taskwait_ast_printer.cpp
+++ b/test/OpenMP/taskwait_ast_printer.cpp
@@ -8,12 +8,28 @@
 
 void foo() {}
 
+template <int a>
+void here() {
+#pragma omp taskwait
+}
+
+// CHECK: template <int a = 5> void here() {
+// CHECK-NEXT:     #pragma omp taskwait
+// CHECK-NEXT: }
+// CHECK: template <int a> void here() {
+// CHECK-NEXT:     #pragma omp taskwait
+// CHECK-NEXT: }
+
 int main (int argc, char **argv) {
   int b = argc, c, d, e, f, g;
   static int a;
 // CHECK: static int a;
 #pragma omp taskwait
 // CHECK-NEXT: #pragma omp taskwait
+
+  here<5>();
+// CHECK-NEXT: here<5>();
+
   return (0);
 }
 


### PR DESCRIPTION
We need to retain the ability to transform executable directives without
associated statements. The upstream version does not yet have this ability.
