### PR TITLE
Avoid checking constraints that are host specific in the OpenMP target

### DIFF
--- a/include/clang/Sema/SemaInternal.h
+++ b/include/clang/Sema/SemaInternal.h
@@ -60,6 +60,18 @@ inline bool DeclAttrsMatchCUDAMode(const LangOptions &LangOpts, Decl *D) {
   return isDeviceSideDecl == LangOpts.CUDAIsDevice;
 }
 
+// Helper function to check whether D's attributes match current language.
+
+inline bool DeclAttrsMatchLanguage(const LangOptions &LangOpts,
+                                   Decl *D) {
+  // In OpenMP target mode we don't care about understanding language specific
+  // atributes
+  if (LangOpts.OpenMPTargetMode)
+    return false;
+
+  return DeclAttrsMatchCUDAMode(LangOpts,D);
+}
+
 // Directly mark a variable odr-used. Given a choice, prefer to use 
 // MarkVariableReferenced since it does additional checks and then 
 // calls MarkVarDeclODRUsed.

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -5847,7 +5847,7 @@ Sema::ActOnVariableDeclarator(Scope *S, Declarator &D, DeclContext *DC,
   ProcessDeclAttributes(S, NewVD, D);
 
   if (getLangOpts().CUDA) {
-    if (EmitTLSUnsupportedError && DeclAttrsMatchCUDAMode(getLangOpts(), NewVD))
+    if (EmitTLSUnsupportedError && DeclAttrsMatchLanguage(getLangOpts(), NewVD))
       Diag(D.getDeclSpec().getThreadStorageClassSpecLoc(),
            diag::err_thread_unsupported);
     // CUDA B.2.5: "__shared__ and __constant__ variables have implied static

--- a/lib/Sema/SemaStmtAsm.cpp
+++ b/lib/Sema/SemaStmtAsm.cpp
@@ -125,7 +125,7 @@ StmtResult Sema::ActOnGCCAsmStmt(SourceLocation AsmLoc, bool IsSimple,
   assert(AsmString->isAscii());
 
   bool ValidateConstraints =
-      DeclAttrsMatchCUDAMode(getLangOpts(), getCurFunctionDecl());
+      DeclAttrsMatchLanguage(getLangOpts(), getCurFunctionDecl());
 
   for (unsigned i = 0; i != NumOutputs; i++) {
     StringLiteral *Literal = Constraints[i];

--- a/test/OpenMP/target_ignore_host_constraint.c
+++ b/test/OpenMP/target_ignore_host_constraint.c
@@ -1,0 +1,26 @@
+// RUN:   %clang -fopenmp -target x86_64-pc-linux-gnu -omptargets=nvptx64sm_35-nvidia-cuda \
+// RUN:   -O3 -S -emit-llvm %s 2>&1
+// RUN:   FileCheck -input-file=target_ignore_host_constraint.ll.tgt-nvptx64sm_35-nvidia-cuda %s
+
+int foo (float myvar)
+{
+  int a;
+  __asm ("pmovmskb %1, %0" : "=r" (a) : "x" (myvar));
+  return a & 0x8;
+}
+
+int bar (int a, float b){
+  int c = a + foo(b);
+
+  // Make sure we generate a target region instead of just crashing because ASM
+  // constraints are not understood by the target
+  // CHECK: define void @__omptgt__0_30dab54_31_(
+  // CHECK-DAG: float*
+  // CHECK-DAG: i32*
+  // CHECK: {
+  // CHECK-NEXT: {{[a-zA-Z0-9_\.]+}}:
+  #pragma omp target
+    b = a+1;
+
+  return b;
+}

--- a/test/OpenMP/target_ignore_host_constraint.c
+++ b/test/OpenMP/target_ignore_host_constraint.c
@@ -14,7 +14,7 @@ int bar (int a, float b){
 
   // Make sure we generate a target region instead of just crashing because ASM
   // constraints are not understood by the target
-  // CHECK: define void @__omptgt__0_30dab54_31_(
+  // CHECK: define void @__omptgt__0_{{[0-9a-f]+_[0-9a-f]+}}_(
   // CHECK-DAG: float*
   // CHECK-DAG: i32*
   // CHECK: {


### PR DESCRIPTION
Hi Alexey,

This patch fixes the issue reported in https://github.com/clang-omp/clang_trunk/issues/13.

It basically prevents the target frontend from checking for host attributes.

Thanks!
Samuel