### PR TITLE
Initialize target library with only a target data

### DIFF
--- a/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -81,8 +81,8 @@ void CGOpenMPRuntime::registerEntryForDeclaration(const Decl *D,
 
 CGOpenMPRuntime::CGOpenMPRuntime(CodeGenModule &CGM)
     : CGM(CGM), DefaultOpenMPPSource(nullptr), NumTargetRegions(0),
-      NumTargetGlobals(0), HasTargetInfoLoaded(false),
-      TargetRegionsDescriptor(nullptr) {
+      NumTargetGlobals(0), HasTargetDataRegions(false),
+      HasTargetInfoLoaded(false), TargetRegionsDescriptor(nullptr) {
   IdentTy = llvm::StructType::create(
       "ident_t", CGM.Int32Ty /* reserved_1 */, CGM.Int32Ty /* flags */,
       CGM.Int32Ty /* reserved_2 */, CGM.Int32Ty /* reserved_3 */,

--- a/lib/CodeGen/CGOpenMPRuntime.h
+++ b/lib/CodeGen/CGOpenMPRuntime.h
@@ -163,6 +163,9 @@ protected:
   // Number of globals processed so far that are to be mapped into a target
   unsigned NumTargetGlobals;
 
+  // True if target data region was processed
+  bool HasTargetDataRegions;
+
   // Name of the current function whose target regions are being identified
   std::string CurTargetParentFunctionName;
 
@@ -284,10 +287,16 @@ public:
   // entry point
   bool isValidOtherTargetFunction(StringRef name);
 
+  // Register target data region
+  void setHasTargetDataRegions(bool val) {
+    HasTargetDataRegions = val;
+  }
+
   // Return true if the current module requires a the target descriptor to be
   // registered
   bool requiresTargetDescriptorRegistry(){
-    return NumTargetRegions != 0 || !TargetGlobalInitializers.empty();
+    return NumTargetRegions != 0 || !TargetGlobalInitializers.empty() ||
+           HasTargetDataRegions;
   }
 
   // Register global initializer for OpenMP Target offloading

--- a/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/lib/CodeGen/CGStmtOpenMP.cpp
@@ -6864,6 +6864,7 @@ void CodeGenFunction::EmitOMPTargetDataDirective(
       EmitFinalOMPClause(*(*I), S);
 
   CGM.OpenMPSupport.endOpenMPRegion();
+  CGM.getOpenMPRuntime().setHasTargetDataRegions(true);
 }
 
 // Generate the instructions for '#pragma omp target update' directive.


### PR DESCRIPTION
This corner case may occur in benchmarks that want to measure data movement.

I didn't know how to implement a test case for the global initializer, but I could verify with a simple program:
```C
int main(int argc, char* argv[])
{
        int a = 0;
        #pragma omp target data map(a)
        {
        }

        return 0;
}
```