### PR TITLE
Add identifiers to offloaded variables

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -3966,7 +3966,7 @@ CodeGenModule::OpenMPSupportStackTy::OMPStackElemTy::OMPStackElemTy(
       Mergeable(false), Schedule(0), ChunkSize(0), NewTask(false),
       Untied(false), HasLastPrivate(false), TaskPrivateTy(0), TaskPrivateQTy(),
       TaskPrivateBase(0), NumTeams(0), ThreadLimit(0), WaitDepsArgs(0),
-      MapsBegin(0), MapsEnd(0), OffloadingDevice(0),
+      CurrentIdentifier(0), MapsBegin(0), MapsEnd(0), OffloadingDevice(0),
       OffloadingHostFunctionCall(0) {}
 
 CodeGenFunction &CodeGenModule::OpenMPSupportStackTy::getCGFForReductionFunction() {
@@ -4379,12 +4379,13 @@ void CodeGenModule::OpenMPSupportStackTy::addOffloadingMap(const Expr* DExpr, ll
   OpenMPStack.back().OffloadingMapSizes.push_back(Size);
   OpenMPStack.back().OffloadingMapTypes.push_back(Type);
 }
-void CodeGenModule::OpenMPSupportStackTy::getOffloadingMapArrays(ArrayRef<const Expr*> &DExprs, ArrayRef<llvm::Value*> &BasePtrs, ArrayRef<llvm::Value*> &Ptrs, ArrayRef<llvm::Value*> &Sizes, ArrayRef<unsigned> &Types){
+void CodeGenModule::OpenMPSupportStackTy::getOffloadingMapArrays(ArrayRef<const Expr*> &DExprs, ArrayRef<llvm::Value*> &BasePtrs, ArrayRef<llvm::Value*> &Ptrs, ArrayRef<llvm::Value*> &Sizes, ArrayRef<unsigned> &Types, ArrayRef<unsigned> &Identifiers){
   DExprs = OpenMPStack.back().OffloadingMapDecls;
   BasePtrs = OpenMPStack.back().OffloadingMapBasePtrs;
   Ptrs  = OpenMPStack.back().OffloadingMapPtrs;
   Sizes = OpenMPStack.back().OffloadingMapSizes;
   Types = OpenMPStack.back().OffloadingMapTypes;
+  Identifiers = OpenMPStack.back().OffloadingMapIdentifiers;
 }
 void CodeGenModule::OpenMPSupportStackTy::setMapsBegin(bool Flag){
   OpenMPStack.back().MapsBegin = Flag;

--- a/lib/CodeGen/CodeGenModule.h
+++ b/lib/CodeGen/CodeGenModule.h
@@ -1270,6 +1270,8 @@ public:
       llvm::SmallVector<llvm::Value *, 8> OffloadingMapPtrs;
       llvm::SmallVector<llvm::Value *, 8> OffloadingMapSizes;
       llvm::SmallVector<unsigned, 8> OffloadingMapTypes;
+      llvm::SmallVector<unsigned, 8> OffloadingMapIdentifiers;
+      unsigned CurrentIdentifier;
       bool MapsBegin;
       bool MapsEnd;
       llvm::Value* OffloadingDevice;
@@ -1322,6 +1324,9 @@ public:
     llvm::Value *getPrevOpenMPPrivateVar(const VarDecl *VD) {
       if (OpenMPStack.size()< 2) return 0;
       return OpenMPStack[OpenMPStack.size() - 2].PrivateVars.count(VD) > 0 ? OpenMPStack[OpenMPStack.size() - 2].PrivateVars[VD] : 0;
+    }
+    unsigned getOffloadingMapCurrentIdentifier() {
+      return OpenMPStack.back().CurrentIdentifier++;
     }
     void startOpenMPRegion(bool NewTask) {
       OpenMPStack.push_back(OMPStackElemTy(CGM));
@@ -1418,7 +1423,7 @@ public:
     void setWaitDepsArgs(llvm::Value **Args);
     llvm::Value **getWaitDepsArgs();
     void addOffloadingMap(const Expr *DExpr, llvm::Value *BasePtr, llvm::Value *Ptr, llvm::Value *Size, unsigned Type);
-    void getOffloadingMapArrays(ArrayRef<const Expr*> &DExprs, ArrayRef<llvm::Value*> &BasePtrs, ArrayRef<llvm::Value*> &Ptrs, ArrayRef<llvm::Value*> &Sizes, ArrayRef<unsigned> &Types);
+    void getOffloadingMapArrays(ArrayRef<const Expr*> &DExprs, ArrayRef<llvm::Value*> &BasePtrs, ArrayRef<llvm::Value*> &Ptrs, ArrayRef<llvm::Value*> &Sizes, ArrayRef<unsigned> &Types, ArrayRef<unsigned> &Identifiers);
     void setOffloadingMapArguments(llvm::ArrayRef<llvm::Value *> Args) {
       for (auto Arg : Args) {
         OpenMPStack.back().offloadingMapArguments.push_back(Arg);


### PR DESCRIPTION
Hi all,

Some of my colleagues and I are currently developing the infrastructure for adding a new device, the cloud, to the list of available targets. Considering the cloud as a device requires few changes to the API of the offloading library (libomptarget). Indeed, our cloud device handles offloading data thanks to files instead of values within an address space. To do so, we had to associate each offloaded variables with a unique identifier. 

As suggested by @sfantao on [OpenMP mailing-list](http://lists.llvm.org/pipermail/openmp-dev/2015-October/000955.html), I submit my patch as pull requests. This part updates Clang behavior (see clang-omp/libomptarget#13 for the other part): 
Clang assigns a unique identifier (as int) to each offloaded variable, then those identifiers are transmitted to libomptarget as an additional argument of the offloading function `__tgt_target`.

Let's us precise that we plan to open source all this work and to submit patches to the upstream Clang/OpenMP repositories when it will be mature enough. Additionally to simplify future integrations, those API changes can be helpful for any exotic offloading target. That's why we propose to integrate them directly.

Regards,
Hervé
