### PR TITLE
Change __kmpc_fork_call prototype to OpenMP standard specification

### DIFF
--- a/lib/CodeGen/CGOpenMPRuntimeTypes.h
+++ b/lib/CodeGen/CGOpenMPRuntimeTypes.h
@@ -26,8 +26,7 @@ enum kmp_proc_bind_t {};
 enum target_size_t {};
 enum target_intptr_t {};
 typedef void (*kmpc_micro)(int32_t *global_tid, int32_t *bound_tid, ...);
-typedef void(__kmpc_fork_call)(ident_t *loc, int32_t argc, kmpc_micro microtask,
-                               void *);
+typedef void(__kmpc_fork_call)(ident_t *loc, int32_t argc, kmpc_micro microtask, ...);
 typedef void(__kmpc_push_num_threads)(ident_t *loc, int32_t global_tid,
                                       int32_t num_threads);
 typedef void(__kmpc_push_proc_bind)(ident_t *loc, int32_t global_tid,


### PR DESCRIPTION
According to [OpenMP specification](http://openmp.llvm.org/Reference.pdf) page 25, __kmpc_fork_call function prototype
is 

```
void __kmpc_fork_call (ident_t ∗loc, kmp_int32 argc, kmpc_micro
microtask,…)
```
and the OpenMP runtime implementation is also satisfied
with OpenMP standard, we can see it in this file http://llvm.org/svn/llvm-project/openmp/trunk/runtime/src/kmp.h. Meanwhile, our clang codegen part is also satisfied with OpenMP standard, so change this will work fine. 